### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 An MCP server providing intelligent transcript processing capabilities, featuring natural formatting, contextual repair, and smart summarization powered by Deep Thinking LLMs.
 
+<a href="https://glama.ai/mcp/servers/in1wo7l928">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/in1wo7l928/badge" alt="TranscriptionTools Server MCP server" />
+</a>
+
 ## Available MCP Tools
 
 This MCP server exposes four powerful tools for transcript processing:


### PR DESCRIPTION
This PR adds a badge for the [TranscriptionTools MCP Server](https://glama.ai/mcp/servers/in1wo7l928) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/in1wo7l928">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/in1wo7l928/badge" alt="TranscriptionTools Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.